### PR TITLE
Add enterprise simulation & ML ground truth roadmap to docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -105,4 +105,10 @@
 
 ---
 
+# Roadmap
+
+- [Enterprise Simulation & ML Ground Truth](roadmap/README.md)
+
+---
+
 <!-- API Documentation is generated separately by rustdoc and available at /api/ after deployment -->

--- a/docs/src/roadmap/README.md
+++ b/docs/src/roadmap/README.md
@@ -1,0 +1,155 @@
+# Roadmap: Enterprise Simulation & ML Ground Truth
+
+This roadmap outlines enhancements, new features, and developer experience (DX) improvements to achieve realistic enterprise simulations with strong ML ground truth. It is organized by themes and phased execution, with options to prioritize based on customer or research needs.
+
+## Guiding Goals
+
+- **Enterprise realism**: simulate multi-entity, multi-region, and multi-system operations with coherent process flows.
+- **ML ground truth**: capture true labels and causal factors for supervised learning, explainability, and evaluation.
+- **Scalability**: handle large volumes with stable performance and repeatable results.
+- **DX productivity**: accelerate experimentation, onboarding, and customization.
+
+## Opportunity Areas & Options
+
+### 1) Enterprise Process Fidelity
+
+**Enhancements**
+- End-to-end process lifecycles (P2P, O2C, R2R, H2R) with realistic timing, approvals, and exceptions.
+- Event-driven transaction chains with constraints (SLA breaches, lead time variance, dependencies).
+- Intercompany elimination logic and cross-entity settlement.
+
+**Feature Options**
+- **Scenario packs** for specific industries (manufacturing, retail, healthcare, finance) with domain-specific master data.
+- **Policy engines** for configurable approvals, delegation of authority, and SOX-style controls.
+- **Operational disruptions** (supply shocks, outages) to drive realistic anomalies.
+
+### 2) Ground Truth & Labeling Frameworks
+
+**Enhancements**
+- Ground truth provenance graph linking transactions, master data, events, and injected anomalies.
+- Label schemas for fraud, compliance violations, process exceptions, and quality defects.
+- Causal metadata for “why” labels exist (source event, rule trigger, or injected scenario).
+
+**Feature Options**
+- **Label confidence scoring** to support semi-supervised workflows.
+- **Counterfactual generation** for sensitivity testing and model robustness.
+- **Bias controls** to vary distributions and class imbalance intentionally.
+
+### 3) Data Quality & Variation Controls
+
+**Enhancements**
+- Structured data quality knobs (missingness, inconsistency, duplicates) at domain granularity.
+- Temporal drift and seasonality modeling at entity or region level.
+- Reference data mutation over time to simulate system migrations.
+
+**Feature Options**
+- **Profile templates** ("clean", "noisy", "legacy") for rapid switching.
+- **Validation contracts** to assert expected error ranges per run.
+
+### 4) System & Integration Realism
+
+**Enhancements**
+- Multi-system source simulation (ERP + CRM + WMS) with reconciliation gaps.
+- Event logs aligned to system-specific schema conventions.
+- Synthetic metadata for system performance (latency, retries, failures).
+
+**Feature Options**
+- **Connector emulator** output (SAP, NetSuite, Dynamics-style exports).
+- **CDC / event stream** exports with offsets and watermarking.
+
+### 5) Observability & Evaluation
+
+**Enhancements**
+- Run-level metadata snapshots (seed, config diff, scenario tags).
+- Evaluation harness with baseline ML tasks and metrics.
+- Audit trails for data generation decisions.
+
+**Feature Options**
+- **Benchmark suites** for process mining, fraud detection, or compliance.
+- **Dashboards** for distribution drift and label coverage.
+
+### 6) Developer Experience (DX)
+
+**Enhancements**
+- Template-driven project scaffolding (industry + data scale + labels).
+- Typed config authoring with schema-aware editor support.
+- Plugin SDK for custom generators and labels.
+
+**Feature Options**
+- **Interactive scenario builder** (CLI or UI) for fast iteration.
+- **Replayable runs** with caching and partial regeneration.
+- **Golden datasets** for regression tests and baseline comparisons.
+
+## Phased Roadmap
+
+### Phase 0–3 months: Foundation & Alignment
+
+**Objectives**
+- Establish reliable ground truth capture and a base enterprise simulation path.
+
+**Key Deliverables**
+- Ground truth provenance graph with unique identifiers and causal links.
+- Baseline lifecycle flows for at least two enterprise processes (e.g., O2C, P2P).
+- Scenario tag system and run metadata snapshots.
+- DX: starter templates and schema-aware validation.
+
+**Success Signals**
+- Labels traceable back to source rules/events in a single hop.
+- Repeatable runs with consistent metadata lineage.
+
+### Phase 3–6 months: Scale & Variation
+
+**Objectives**
+- Introduce variation and realism to stress ML training and evaluation.
+
+**Key Deliverables**
+- Data quality knobs with templates (clean/noisy/legacy).
+- Temporal drift and seasonality modeling.
+- Industry-specific scenario packs (at least one vertical).
+- Evaluation harness with baseline ML tasks and metrics.
+
+**Success Signals**
+- Demonstrable control over label prevalence and drift.
+- Benchmarks producing stable metrics across multiple runs.
+
+### Phase 6–12 months: Enterprise Realism & Integrations
+
+**Objectives**
+- Expand to multi-entity operations and system integrations.
+
+**Key Deliverables**
+- Intercompany logic with elimination and settlement.
+- Multi-system source exports and CDC output.
+- Policy engine for approvals and control checks.
+- DX: plugin SDK with documented extension points.
+
+**Success Signals**
+- Realistic cross-entity workflows with reconciliation gaps.
+- External system formats consumed by downstream ML pipelines.
+
+### Phase 12+ months: Advanced Simulation & Research Features
+
+**Objectives**
+- Enable advanced ML research and enterprise-scale testing.
+
+**Key Deliverables**
+- Counterfactual generation and causal ground truth.
+- Operational disruption modeling at scale.
+- Benchmark suites with standardized leaderboards.
+- Interactive scenario builder for non-technical users.
+
+**Success Signals**
+- Research teams can run controlled experiments with configurable causality.
+- Multiple benchmark suites adopted for evaluation and regression.
+
+## Dependencies & Risks
+
+- **Schema and config stability**: ensure backward compatibility as new labels and metadata are introduced.
+- **Performance**: larger simulations may require memory optimization and parallelization.
+- **Validation**: avoid unrealistic combinations of rules/labels that could distort ML training.
+
+## Next Steps
+
+- Prioritize process flows and verticals based on target users.
+- Identify baseline ML tasks to drive evaluation harness design.
+- Define acceptance criteria for ground truth lineage and label schemas.


### PR DESCRIPTION
### Motivation
- Provide a concise, actionable roadmap that outlines enhancements for enterprise realism, ML ground truth, and developer experience.
- Make the roadmap easily discoverable in the documentation navigation so teams can plan and prioritize feature work.

### Description
- Add `docs/src/roadmap/README.md` containing goals, opportunity areas, phased deliverables, dependencies, and next steps for enterprise simulation and ML ground truth.
- Update `docs/src/SUMMARY.md` to register the new Roadmap page under the mdBook navigation.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697244cf4b908323a316672914526f2a)